### PR TITLE
Colored output of warnings & errors + statistics

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/wikimedia/grunt-stylelint",
   "dependencies": {
     "color": "^0.11.1",
-    "stylelint": "6.3.3"
+    "stylelint": "^6.5.1"
   },
   "devDependencies": {
     "grunt": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "homepage": "https://github.com/wikimedia/grunt-stylelint",
   "dependencies": {
-      "stylelint": "6.3.3"
+    "color": "^0.11.1",
+    "stylelint": "6.3.3"
   },
   "devDependencies": {
     "grunt": "1.0.1",


### PR DESCRIPTION
Now errors and warnings are written to the console. Using color to create a better distinction. To get a quick overview, a statistical line counting errors and warnings is written to console after each file, and at the end.