### PR TITLE
Update stylelint dependency version to use caret range

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/wikimedia/grunt-stylelint",
   "dependencies": {
-      "stylelint": "6.8.0"
+      "stylelint": "^6.8.0"
   },
   "devDependencies": {
     "grunt": "1.0.1",


### PR DESCRIPTION
As per @jeddy3 [comment](https://github.com/wikimedia/grunt-stylelint/pull/15#issuecomment-229980322) it makes more sense to use [caret range](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004) instead of a specific version.

`gulp-stylelint`, `broccoli-stylelint`, `stylelint-webpack-plugin` follow the same idea.