### PR TITLE
Travis CI: Cache NPM modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 sudo: false
 language: node_js
+cache:
+  directories:
+    - node_modules
 node_js:
   - "4"
   - "6"
+before_install:
+  # remove outdated deps, assists with cache maintenance
+  - npm prune
+  - npm update
 notifications:
   irc:
     channels:


### PR DESCRIPTION
This should decrease Travis CI's job time eliminating most of the time taken to perform `npm install` in each job.