### PR TITLE
Support output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/wikimedia/grunt-stylelint.svg?branch=master)](https://travis-ci.org/wikimedia/grunt-stylelint)
 [![dependencies Status](https://david-dm.org/wikimedia/grunt-stylelint/status.svg)](https://david-dm.org/wikimedia/grunt-stylelint)
 [![devDependencies Status](https://david-dm.org/wikimedia/grunt-stylelint/dev-status.svg)](https://david-dm.org/wikimedia/grunt-stylelint?type=dev)
-[![NPM Downloads](https://img.shields.io/npm/dm/grunt-stylelint.svg)](https://www.npmjs.org/package/grunt-stylelint) 
+[![NPM Downloads](https://img.shields.io/npm/dm/grunt-stylelint.svg)](https://www.npmjs.org/package/grunt-stylelint)
 
 # grunt-stylelint
 > Grunt plugin for running Stylelint

--- a/README.md
+++ b/README.md
@@ -30,3 +30,30 @@ Running and configuring
 _Run this task with the `grunt stylelint` command._
 
 You can specify the targets and options for the task using the normal Grunt configuration – see Grunt's [guide on how to configure tasks](http://gruntjs.com/configuring-tasks) in general.
+
+The `options` object is passed through to `stylelint`. Options you may wish to set are:
+
+#### formatter
+Type: `string`
+Default value: `"string"`
+Values: `"string"`|`"verbose"`|`"json"`
+
+Which output format in which you would like results. If `grunt` is run with `--verbose` and this is not explicitly set, it will act as though you passed in `"verbose"`.
+
+#### syntax
+Type: `string`
+Values: `"scss"`|`"less"`|`"sugarss"`
+
+Which syntax standard should be used to parse source stylesheets. If this is unset, `stylelint` will attempt to guess which syntax is used by the files' extensions.
+
+#### ignoreDisables
+Type: `boolean`
+Default vaue: `false`
+
+Whether to ignore inline comments that disable stylelint.
+
+#### reportNeedlessDisables
+Type: `boolean`
+Default vaue: `false`
+
+Whether to ignore inline comments that disable stylelint and report which ones did not block a lint warning.

--- a/tasks/grunt-stylelint.js
+++ b/tasks/grunt-stylelint.js
@@ -14,7 +14,7 @@ module.exports = function ( grunt ) {
 		options.files = this.filesSrc.filter( function ( file ) {
 			return grunt.file.isFile( file );
 		} );
-		options.formatter = verbose ? 'verbose' : 'string';
+		options.formatter = options.formatter || ( verbose ? 'verbose' : 'string' );
 
 		styleLint.lint( options ).then( function ( data ) {
 			if ( data.output ) {


### PR DESCRIPTION
Provide for users to pass in "json" as an option, and not assume that running
in `grunt --verbose` trumps wanting the format in an explicit way. Also, add
documentation to the README of the other main options users can pass in.

Addresses #26 somewhat.
