### PR TITLE
Use peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   },
   "homepage": "https://github.com/wikimedia/grunt-stylelint",
   "dependencies": {
-    "chalk": "1.1.3",
-    "stylelint": "7.8.0"
+    "chalk": "1.1.3"
+  },
+  "peerDependencies": {
+    "stylelint": "7.9.0"
   },
   "devDependencies": {
     "eslint-config-wikimedia": "0.3.0",
@@ -30,6 +32,7 @@
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-nodeunit": "1.0.0",
     "grunt-contrib-watch": "1.0.0",
-    "grunt-eslint": "19.0.0"
+    "grunt-eslint": "19.0.0",
+    "stylelint": "7.9.0"
   }
 }


### PR DESCRIPTION
Move stylelint package to peer dependencies and upgrade it to the latest version.

---

There is an issue with Stylelint 7.8.0 (using rule-empty-line-before with the exception for 'first-nested' doesn't work). This issue is solved in Stylelint 7.9.0.

Upgrading the Stylelint version in package.json of this project is a short-term solution since in the future a similar issue might arise. The long-term solution would be to move the stylelint package to peer dependencies so each project that uses grunt-stylelint may use their local version of Stylelint and easily update to the latest version.
