### PR TITLE
Change stylelint peerDependencies to ^7.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "chalk": "1.1.3"
   },
   "peerDependencies": {
-    "stylelint": "7.9.0"
+    "stylelint": "^7.8.0"
   },
   "devDependencies": {
     "eslint-config-wikimedia": "0.3.0",


### PR DESCRIPTION
This means we don't have to keep doing releases but it's easy for downstream users to pin versions.