### PR TITLE
build: Force lodash (dependency of table) to older version (Fixes #49)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "grunt-contrib-nodeunit": "1.0.0",
     "grunt-contrib-watch": "1.0.0",
     "grunt-eslint": "19.0.0",
+    "lodash": "4.17.4",
     "stylelint": "9.0.0"
   }
 }


### PR DESCRIPTION
This is a terrible hack, but it seems that 4.17.4 works and 4.17.5
breaks the output entirely, so for now let's get this shipped to
unbreak the world and we can undo it later when upstream have fixed
things or there's a better solution out there.