### PR TITLE
build: Bump various devDependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
     "stylelint": "^9.0.0"
   },
   "devDependencies": {
-    "eslint-config-wikimedia": "0.3.0",
-    "grunt": "1.0.1",
+    "eslint-config-wikimedia": "0.5.0",
+    "grunt": "1.0.2",
     "grunt-cli": "1.2.0",
-    "grunt-contrib-clean": "1.0.0",
+    "grunt-contrib-clean": "1.1.0",
     "grunt-contrib-nodeunit": "1.0.0",
     "grunt-contrib-watch": "1.0.0",
-    "grunt-eslint": "19.0.0",
+    "grunt-eslint": "20.1.0",
     "lodash": "4.17.4",
     "stylelint": "9.0.0"
   }


### PR DESCRIPTION
 eslint-config-wikimedia   0.3.0  →   0.5.0
 grunt                     1.0.1  →   1.0.2
 grunt-contrib-clean       1.0.0  →   1.1.0
 grunt-eslint             19.0.0  →  20.1.0