### PR TITLE
Use correct stylelint `syntax` option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,7 +23,7 @@ module.exports = function ( grunt ) {
 			simple: {
 				options: {
 					configFile: 'test/simple/.stylelintrc',
-					format: 'less'
+					syntax: 'less'
 				},
 				src: 'test/simple/**/*.{css,less}'
 			},
@@ -31,7 +31,7 @@ module.exports = function ( grunt ) {
 				options: {
 					outputFile: 'tmp/outputFile/report.txt',
 					configFile: 'test/simple/.stylelintrc',
-					format: 'less',
+					syntax: 'less',
 					failOnError: false
 				},
 				src: 'test/output/**/*.{css,less}'


### PR DESCRIPTION
The correct option name for declaring a _non-standard syntax_ is `syntax`, not `format`:
• https://github.com/wikimedia/grunt-stylelint/blob/master/README.md#syntax
• https://stylelint.io/user-guide/node-api/#syntax