### PR TITLE
build: Remove redundant 'npm@latest' for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ cache:
 node_js:
   - "6"
   - "8"
-before_install:
-  - npm install -g npm@latest
 notifications:
   irc:
     channels:


### PR DESCRIPTION
Use the npm version that comes with the Node release instead.
Ensuring latest can break it given it bypasses sem-ver and other
protections. It also makes it more realistic compared to what
developers and/or production would use as npm version with a
given Node release.