### PR TITLE
build: Bump devDependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,15 @@
     "stylelint": "^9.0.0"
   },
   "devDependencies": {
-    "eslint-config-wikimedia": "0.5.0",
-    "grunt": "1.0.2",
-    "grunt-cli": "1.2.0",
+    "eslint-config-wikimedia": "0.7.2",
+    "eslint-plugin-qunit": "3.3.0",
+    "grunt": "1.0.3",
+    "grunt-cli": "1.3.1",
     "grunt-contrib-clean": "1.1.0",
-    "grunt-contrib-nodeunit": "1.0.0",
-    "grunt-contrib-watch": "1.0.0",
-    "grunt-eslint": "20.1.0",
-    "lodash": "4.17.4",
+    "grunt-contrib-nodeunit": "2.0.0",
+    "grunt-contrib-watch": "1.1.0",
+    "grunt-eslint": "21.0.0",
+    "lodash": "4.17.10",
     "stylelint": "9.0.0"
   }
 }


### PR DESCRIPTION
 eslint-config-wikimedia   0.5.0  →    0.7.2
   + eslint-plugin-qunit   3.3.0
 grunt                     1.0.2  →    1.0.3
 grunt-cli                 1.2.0  →    1.3.1
 grunt-contrib-nodeunit    1.0.0  →    2.0.0
 grunt-contrib-watch       1.0.0  →    1.1.0
 grunt-eslint             20.1.0  →   21.0.0
 lodash                   4.17.4  →  4.17.10