### PR TITLE
Update chalk dependency to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/wikimedia/grunt-stylelint",
   "dependencies": {
-    "chalk": "1.1.3"
+    "chalk": "2.4.2"
   },
   "peerDependencies": {
     "stylelint": "^10.0.0"


### PR DESCRIPTION
Since this package no longer supports Node 4, it's safe to update `chalk`.