### PR TITLE
Drop Node 8 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   "peerDependencies": {
     "stylelint": "^13.3.2"
   },
+  "engines": {
+    "node": ">=10"
+  },
   "devDependencies": {
     "eslint-config-wikimedia": "0.15.2",
     "grunt": "1.1.0",


### PR DESCRIPTION
This is required to keep updating our dependencies.