### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Default value: `true`
 
 Whether to fail if stylelint detects an error.
 
-#### syntax
+#### fix
 Type: `boolean`
 Default value: `false`
 


### PR DESCRIPTION
Fix a typo in the README where the wrong header name was used.